### PR TITLE
Depend on middleman-core, middleman-sprockets instead of full middleman package

### DIFF
--- a/middleman-autoprefixer.gemspec
+++ b/middleman-autoprefixer.gemspec
@@ -16,12 +16,14 @@ Gem::Specification.new do |spec|
   spec.test_files    = `git ls-files -- {features,fixtures}/*`.split($/)
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'middleman', '~> 3.2'
+  spec.add_dependency 'middleman-core', '~> 3.2'
+  spec.add_dependency 'middleman-sprockets', '~> 3.2'
   spec.add_dependency 'autoprefixer-rails', '~> 1.1.20140302'
 
   spec.add_development_dependency 'bundler', '~> 1.5'
   spec.add_development_dependency 'rake', '~> 10.1'
 
+  spec.add_development_dependency 'middleman', '~> 3.2'
   spec.add_development_dependency 'cucumber', '~> 1.3.14'
   spec.add_development_dependency 'aruba', '~> 0.5.4'
 end


### PR DESCRIPTION
Middleman-autoprefixer actually requires only middleman-core and middleman-sprockets. Full middleman package (haml, sass, compass, ...) is required only for testing.
