### PR TITLE
Prefixing fails when a proxy has removed the file extension.

### DIFF
--- a/features/autoprefixer.feature
+++ b/features/autoprefixer.feature
@@ -55,3 +55,12 @@ Feature: Postprocessing stylesheets with Autoprefixer in different configuration
     When I go to "/stylesheets/nope.css"
     Then I should not see "-ms-border-radius"
     And I should see "border-radius"
+
+  Scenario: With arbitrary proxy paths
+    Given the Server is running at "proxy-app"
+    When I go to "/proxy"
+    Then I should not see "-ms-border-radius"
+    And I should see "border-radius"
+    When I go to "/proxy-inline"
+    Then I should not see "-ms-border-radius"
+    And I should see "border-radius"

--- a/fixtures/proxy-app/config.rb
+++ b/fixtures/proxy-app/config.rb
@@ -1,0 +1,4 @@
+activate :autoprefixer, inline: true
+
+proxy '/proxy', '/stylesheets/page.css', ignore: true
+proxy '/proxy-inline', '/index.html', ignore: true

--- a/fixtures/proxy-app/source/index.html
+++ b/fixtures/proxy-app/source/index.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+</head>
+<body>
+<style>
+  input {
+    -ms-border-radius: 5px;
+    border-radius: 5px;
+  }
+</style>
+</body>
+</html>

--- a/fixtures/proxy-app/source/stylesheets/page.scss
+++ b/fixtures/proxy-app/source/stylesheets/page.scss
@@ -1,0 +1,4 @@
+input {
+  -ms-border-radius: 5px;
+  border-radius: 5px;
+}


### PR DESCRIPTION
This change permits arbitrary proxy paths by relying on content type rather than file extension.