### PR TITLE
Added default MIME type when not present

### DIFF
--- a/lib/middleman-autoprefixer/extension.rb
+++ b/lib/middleman-autoprefixer/extension.rb
@@ -42,7 +42,7 @@ module Middleman
         def call(env)
           status, headers, response = @app.call(env)
 
-          type = headers['Content-Type'].split(';').first
+          type = headers.fetch('Content-Type', 'application/octet-stream').split(';').first
           path = env['PATH_INFO']
 
           prefixed = process(response, type, path)


### PR DESCRIPTION
Sometimes headers do not contain MIME type. According to the
specification the "default" type is `application/octet-stream`. It
should be returned each time instead of empty `'Content-Type'`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/middleman/middleman-autoprefixer/16)
<!-- Reviewable:end -->
