### PR TITLE
Fix v2.8.0 release header in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v2.6.0
+# v2.8.0
 
 * Updated Autoprefixer to 7.0.
 


### PR DESCRIPTION
I was doing some work on [dependencies.io](https://www.dependencies.io) and noticed this. Looks like it was just a typo...?