### PR TITLE
Update autoprefixer-rails dependency to 8.0

### DIFF
--- a/middleman-autoprefixer.gemspec
+++ b/middleman-autoprefixer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'middleman-core',     '>= 3.3.3'
-  spec.add_runtime_dependency 'autoprefixer-rails', '>= 7.0.1', '< 8.0.0'
+  spec.add_runtime_dependency 'autoprefixer-rails', '~> 8.0'
 
   spec.add_development_dependency 'bundler',        '>= 1.14'
   spec.add_development_dependency 'rake',           '>= 10.3'


### PR DESCRIPTION
- [Release](https://github.com/ai/autoprefixer-rails/releases/tag/8.0.0)
- [Change log](https://github.com/ai/autoprefixer-rails/blob/master/CHANGELOG.md)