### PR TITLE
Update autoprefixer-rails dependency to >= 9.1.4

### DIFF
--- a/middleman-autoprefixer.gemspec
+++ b/middleman-autoprefixer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'middleman-core',     '>= 3.3.3'
-  spec.add_runtime_dependency 'autoprefixer-rails', '~> 8.0'
+  spec.add_runtime_dependency 'autoprefixer-rails', '>= 9.1.4'
 
   spec.add_development_dependency 'bundler',        '>= 1.14'
   spec.add_development_dependency 'rake',           '>= 10.3'


### PR DESCRIPTION
autoprefixer-rails 9.1.4 fixes the issue described here: https://github.com/ai/autoprefixer-rails/issues/130.
I can reproduce this bug when using autoprefixer-rails 8.6.5, which is the latest 8.* version.
I hope you don't see any issues in requiring 9.*.