### PR TITLE
Bump autoprefixer-rails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rvm:
   - 2.2.7
 before_install:
   - nvm install 10
-  - gem install bundler
 gemfile:
   - Gemfile
   - Gemfile3

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ rvm:
   - 2.4.1
   - 2.3.4
   - 2.2.7
+before_install:
+  - nvm install 10
 gemfile:
   - Gemfile
   - Gemfile3

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.2.7
 before_install:
   - nvm install 10
+  - gem install bundler
 gemfile:
   - Gemfile
   - Gemfile3

--- a/middleman-autoprefixer.gemspec
+++ b/middleman-autoprefixer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'middleman-core',     '>= 3.3.3'
-  spec.add_runtime_dependency 'autoprefixer-rails', '~> 9.1'
+  spec.add_runtime_dependency 'autoprefixer-rails', '~> 10.0'
 
   spec.add_development_dependency 'bundler',        '>= 1.14'
   spec.add_development_dependency 'rake',           '>= 10.3'


### PR DESCRIPTION
Problem
-------

`autoprefixer-rails` v 9.x was reporting deprecation warnings everytime
you did a build or serve.

```
DEPRECATION WARNING: autoprefixer-rails was deprected. Migration guide:
https://github.com/ai/autoprefixer-rails/wiki/Deprecated (called from load at /Users/jon/.rbenv/versions/2.6.5/bin/middleman:23)
```

Some futher investigation makes me think it's not in fact deprecated but
has picked up some new owners and is still in development.

Solution
---------

Bump to the new version (10.0.1) to suppress the error message.

I tested this locally by building a current middleman project and the
css that came out was identical to the previous version.  Also your
tests still pass.